### PR TITLE
Aktualizacja README i dodanie przewodnika aktualizacji

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,33 @@
 # Mail Log Plugin
 
-View mail messages with their recorded time and details.
+Log every email your [October CMS](https://octobercms.com) site sends — with delivery status, open tracking and
+resend.
 
-Plugin automatically logs all outgoing emails send through your October CMS project after installation. This is very useful when you need to check user received important email or just check if emails are send successfully.
+**Demo URL:** https://october-demo.renatio.com/backend/backend/auth/signin  
+**Login:** maillog  
+**Password:** maillog
+
+Check whether a user received an important email, or simply confirm that mail is going out at all.
 
 ## Features
 
-* Log all outgoing emails
-* Track user open clicks
-* Automatically prune old mail logs
-* Work out of the box
+* Log all outgoing emails, with a cap on the size kept
+* Delivery status: sent, failed with the recorded error, or pending
+* Resend a logged message to its original recipients
+* Optional storage of sent attachments, with download and resend
+* Skip the body of chosen templates, so a password reset link never lands in the log
+* Open tracking
+* Mail Activity dashboard widget
+* CSV export
+* Automatic pruning of old logs
+* Fine-grained permissions
+* Works out of the box
+
+## Requirements
+
+This plugin requires October CMS 4.x and PHP 8.3 or newer.
+
+If you are running October CMS 3.x or older, use the 1.x branch of this plugin.
 
 ## Why is this a paid plugin?
 
@@ -28,7 +46,7 @@ you feel is missing but valuable.
 
 ## Like this plugin?
 
-If you like this plugin, give this plugin a Like or Make donation with [PayPal](https://www.paypal.me/mplodowski).
+If you like this plugin, give this plugin a like or make a donation with [PayPal](https://www.paypal.me/mplodowski).
 
 ## My other plugins
 
@@ -36,8 +54,8 @@ Please check my other [plugins](https://octobercms.com/author/Renatio).
 
 ## Support
 
-Please use [GitHub Issues Page](https://github.com/mplodowski/maillog-plugin-public/issues) to report any issues
-with plugin.
+Please use [GitHub Issues Page](https://github.com/mplodowski/maillog-plugin-public/issues) to report any issues with
+the plugin.
 
 > Reviews should not be used for getting support or reporting bugs, if you need support please use the Plugin support
 > link.
@@ -49,21 +67,111 @@ from [www.flaticon.com](https://www.flaticon.com/).
 
 ## Usage
 
-Plugin will work out of the box after installation. It will log all mail send from October CMS.
+The plugin works out of the box. It logs every mail sent from October CMS, including mail sent from other plugins and
+from the queue.
+
+The log lives in Settings -> Logs -> Mail Logs. Click a record to open its preview, which shows the message details and
+renders the original message body.
 
 ## Settings
 
-Plugin register new Settings menu item in Settings -> Logs -> Mail Log Settings
+Settings -> Logs -> Mail Log Settings.
 
 ### Prune period in days
 
-This will prune records older than specified number of days. The default value is 30 days.
+Records older than this are deleted once a day by a scheduled task. The default is 30 days; `0` or empty keeps
+records forever. Logged messages hold the full mail body and the recipient IP address, so keeping them indefinitely
+should be a deliberate choice.
 
 > **Important note:** For scheduled tasks to operate correctly you must set up the
-> scheduler: https://docs.octobercms.com/3.x/setup/scheduler.html
+> scheduler: https://docs.octobercms.com/4.x/setup/scheduler.html
 
-### Track open clicks
+### Track when user opens email
 
-When this is feature is enabled, plugin will add invisible image to sent email to track when user opens it.
+Adds an invisible image to every HTML message to record when it is opened. Enabled by default.
 
-This is enabled by default.
+Open tracking is a best-effort signal: many mail clients block remote images, and privacy proxies fetch them without
+the recipient reading the message. When tracking is off, the open columns and the **Opened** filter disappear from the
+list.
+
+### Maximum message size in MB
+
+Caps the copy of the message body kept in the log; the message itself always goes out whole. The default is 1 MB,
+`0` keeps every body in full. Templates that inline images as base64 write megabytes into the log on every send,
+which is what this limit is for.
+
+A truncated message cannot be resent, and the preview says so.
+
+### Templates whose content is not stored
+
+Messages built from the templates named here are logged with their recipients, subject and status, but without their
+content. Use it for mail carrying a secret, such as the password reset link. Such a message cannot be resent.
+
+### Store attachments
+
+Keeps a copy of every attachment sent, so it can be downloaded from the preview and included in a resend. Disabled by
+default.
+
+Copies are written outside the web root, under `storage/app/uploads/protected`, and can only be downloaded by users
+with the `renatio.maillog.manage_logs.attachments` permission; everyone else sees the file names as plain text. Files
+are stored only once the mail transport has accepted the message, and images embedded with `cid:` are not stored.
+Stored files are removed together with their log record, whether it is deleted, emptied or pruned.
+
+### Maximum attachment size in MB
+
+Attachments larger than this are not stored; only their name stays in the log. The default is 10 MB, `0` stores
+everything. The whole attachment is read into memory to be measured, so a generous limit needs a matching PHP
+`memory_limit`.
+
+## Delivery status
+
+| Status  | Meaning                                                              |
+|---------|----------------------------------------------------------------------|
+| Sent    | The mail transport accepted the message.                             |
+| Failed  | Sending threw an error; the error message is recorded on the record. |
+| Pending | The message was logged, but no outcome has been recorded yet.        |
+
+> **Note:** A queued mailable is logged again on every attempt, so a message that fails twice before finally being
+> delivered leaves two failed rows plus one sent row.
+
+## Resend
+
+The preview has a **Resend** button for users with the `renatio.maillog.manage_logs.resend` permission. It sends the
+stored body and subject to the original To, CC and BCC recipients, with the stored attachments where available, using
+the mail configuration currently in effect. The original sender and reply-to address are not reused.
+
+The resent message is logged as a new record, and the original record keeps who resent it and when.
+
+## Filters
+
+* **Template** - the mail template the message was built from
+* **Sent** / **Failed** - delivery outcome
+* **Opened** - opened at least once (hidden when open tracking is off)
+* **Created at** - a date range
+
+The **From** and **Last Opened** columns are hidden by default; turn them on with the list setup button.
+
+## Mail Activity dashboard widget
+
+Add it on the dashboard with **Add widget** -> *Mail Activity*. It shows the total logged, sent, opened and failed
+messages for the last `days` days (7 by default). The figures are cached for one minute.
+
+## Export
+
+The **Export** button in the list toolbar, available with the `renatio.maillog.manage_logs.export` permission, exports
+the whole log to CSV, streamed in chunks so a large log does not exhaust memory.
+
+## Permissions
+
+| Permission                                    | Grants                                                   |
+|-----------------------------------------------|----------------------------------------------------------|
+| `renatio.maillog.manage_logs`                 | Access to the Mail Logs list and the dashboard widget.   |
+| `renatio.maillog.manage_logs.preview`         | Opening the preview of a single logged message.          |
+| `renatio.maillog.manage_logs.delete`          | Deleting selected records from the list.                 |
+| `renatio.maillog.manage_logs.truncate`        | Emptying the whole log with the "Empty Mail Log" button. |
+| `renatio.maillog.manage_logs.export`          | Exporting the log to CSV.                                |
+| `renatio.maillog.manage_logs.resend`          | Resending a logged message from its preview.             |
+| `renatio.maillog.manage_logs.attachments`     | Downloading a stored attachment from the preview.        |
+| `renatio.maillog.manage_settings`             | Access to the Mail Log Settings page.                    |
+
+`renatio.maillog.manage_logs` is required to reach the list at all; the other permissions gate individual actions.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,53 @@
+# Upgrade guide
+
+## Upgrading To 2.0.0
+
+The plugin requires October CMS 4.x. If you are still running October CMS 3, stay on the 1.x branch.
+
+## Upgrading To 2.0.6
+
+The controller action `previewEmail` was renamed to `preview_email`. Update any code that extends the `MailLogs`
+controller or links to that action directly.
+
+## Upgrading To 2.1.0
+
+* Run `php artisan october:migrate`.
+* Grant the new `utilities.mail_logs.resend` permission to the roles that should be able to resend mail.
+* If you serve a mirrored public folder, run `php artisan october:mirror`, or the Mail Activity widget renders
+  unstyled.
+
+## Upgrading To 2.2.0
+
+Attachment storage is off by default. To use it, enable **Store attachments** in the settings and grant the new
+`utilities.mail_logs.attachments` permission to the roles that should be able to download stored files.
+
+## Upgrading To 2.3.0
+
+Run `php artisan october:migrate`.
+
+Message bodies are now capped at 1 MB in the log. Set **Maximum message size in MB** to `0` to keep every body in
+full, as before.
+
+## Upgrading To 2.4.0
+
+Run `php artisan october:migrate`.
+
+## Upgrading To 3.0.0
+
+The plugin requires PHP 8.3 or newer; upgrade the runtime before running Composer.
+
+The permission codes changed, so run `php artisan october:migrate`. The migration rewrites existing grants, so nobody
+loses access. The permissions also moved from the **Utilities** tab into their own **Mail Logs** tab.
+
+| Before                            | After                                       |
+|-----------------------------------|---------------------------------------------|
+| `utilities.mail_logs`             | `renatio.maillog.manage_logs`               |
+| `utilities.mail_logs.preview`     | `renatio.maillog.manage_logs.preview`       |
+| `utilities.mail_logs.delete`      | `renatio.maillog.manage_logs.delete`        |
+| `utilities.mail_logs.truncate`    | `renatio.maillog.manage_logs.truncate`      |
+| `utilities.mail_logs.export`      | `renatio.maillog.manage_logs.export`        |
+| `utilities.mail_logs.resend`      | `renatio.maillog.manage_logs.resend`        |
+| `utilities.mail_logs.attachments` | `renatio.maillog.manage_logs.attachments`   |
+| `utilities.mail_logs_settings`    | `renatio.maillog.manage_settings`           |
+
+If your own code calls `hasAccess()` or `userHasAccess()` with one of the old codes, update those calls.


### PR DESCRIPTION
## Zmiany

- `README.md` zsynchronizowany z dokumentacją pluginu w wersji 3.0: nowe funkcje (status dostarczenia, resend, załączniki, pomijanie treści wybranych szablonów, limit rozmiaru, widget, eksport), wymagania (October 4.x, PHP 8.3), pełne opisy ustawień, filtrów i tabela uprawnień, link do demo.
- Dodany `UPGRADE.md` z krokami aktualizacji od 2.0.0 do 3.0.0 (migracje, nowe uprawnienia, mapowanie starych kodów uprawnień na nowe).

Pliki są kopią 1:1 z repozytorium pluginu.